### PR TITLE
Chore mulang 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "node-getopt": "^0.2.3",
     "node-jsdom": "^3.1.5",
     "proceds-blockly": "git://github.com/Program-AR/proceds-blockly.git#0.1.12",
-    "xmlshim": "^0.2.3"
+    "xmlshim": "^0.2.3",
+    "libxmljs": "0.19.7"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/src/mulang.js
+++ b/src/mulang.js
@@ -190,9 +190,31 @@ function parseValue(string) {
 
   switch (value) {
     case "==":
-      return s("Equal")
+      return primitive("Equal")
     case "/=":
-      return s("NotEqual")
+      return primitive("NotEqual")
+    case "+":
+      return primitive("Plus")
+    case "-":
+      return primitive("Minus")
+    case "*":
+      return primitive("Multiply")
+    case "/":
+      return primitive("Minus")
+    case "not":
+      return primitive("Negation")
+    case "&&":
+      return primitive("And")
+    case "||":
+      return primitive("Or")
+    case ">=":
+      return primitive("GreatherOrEqualThan")
+    case ">":
+      return primitive("GreatherThan")
+    case "<=":
+      return primitive("LessOrEqualThan")
+    case "<":
+      return primitive("LessThan")
     default:
       return reference(value);
   }
@@ -223,6 +245,10 @@ function reference(name) {
   return s("Reference", name);
 }
 
+function primitive(name) {
+  return s("Primitive", name);
+}
+
 //-------------
 //-- Exports --
 //-------------
@@ -231,5 +257,6 @@ module.exports = {
   parse: parse,
   s: s,
   callable: callable,
-  reference: reference
+  reference: reference,
+  primitive: primitive
 };

--- a/test/mulang-spec.js
+++ b/test/mulang-spec.js
@@ -7,6 +7,7 @@ var mulang = require("../src/mulang");
 var s = mulang.s;
 var callable = mulang.callable;
 var reference = mulang.reference;
+var primitive = mulang.primitive;
 
 function program(body) {
   return entryPoint("program", body);
@@ -141,7 +142,7 @@ describe("gobstones - mulang", function() {
     var code = gbs("program{x:= z && y}");
 
     code.should.eql(
-      program(s("Assignment", ["x", s("Application", [reference("&&"), [reference("z"), reference("y")]])]))
+      program(s("Assignment", ["x", s("Application", [primitive("And"), [reference("z"), reference("y")]])]))
     );
   });
 
@@ -149,7 +150,29 @@ describe("gobstones - mulang", function() {
     var code = gbs("program{x:= not z}");
 
     code.should.eql(
-      program(s("Assignment", ["x", s("Application", [reference("not"), [reference("z")]])]))
+      program(s("Assignment", ["x", s("Application", [primitive("Negation"), [reference("z")]])]))
+    );
+  });
+
+  it("translates >=", function() {
+    var code = gbs("program{x:= m >= z}");
+    code.should.eql(
+      program(s("Assignment", ["x", s("Application", [primitive("GreatherOrEqualThan"), [reference("m"), reference("z")]])]))
+    );
+  });
+
+  it("translates <=", function() {
+    var code = gbs("program{x:= m <= z}");
+    code.should.eql(
+      program(s("Assignment", ["x", s("Application", [primitive("LessOrEqualThan"), [reference("m"), reference("z")]])]))
+    );
+  });
+
+  it("translates +", function() {
+    var code = gbs("program{x:= m + z}");
+
+    code.should.eql(
+      program(s("Assignment", ["x", s("Application", [primitive("Plus"), [reference("m"), reference("z")]])]))
     );
   });
 
@@ -161,9 +184,9 @@ describe("gobstones - mulang", function() {
         s("Assignment", [
           "x",
           s("Application", [
-            reference("&&"), [
-              s("Application", [s("Equal"),    [s("MuBool", true), s("MuNumber", 2.0)]]),
-              s("Application", [s("NotEqual"), [reference("x"), reference("t")]])
+            primitive("And"), [
+              s("Application", [primitive("Equal"),    [s("MuBool", true), s("MuNumber", 2.0)]]),
+              s("Application", [primitive("NotEqual"), [reference("x"), reference("t")]])
             ]])]))
     );
   });


### PR DESCRIPTION
# :dart: Goal

Add support for new mulang primitives, and removing deprecated use of `s("Equal")` and `s("NotEqual")`

# :back: Backward compatibility

This PR is not backwards compatible, since it changes the Mulang AST output format. 